### PR TITLE
Create App wrapper component with ThemeProvider

### DIFF
--- a/components/index.js
+++ b/components/index.js
@@ -1,0 +1,3 @@
+import theme from './theme';
+
+export { theme };

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,7 +1,3 @@
-/**
- * Implement Gatsby's Browser APIs in this file.
- *
- * See: https://www.gatsbyjs.org/docs/browser-apis/
- */
+import wrapRootElement from './src/components/wrap-root-element';
 
-// You can delete this file if you're not using it
+export { wrapRootElement };

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,7 +1,3 @@
-/**
- * Implement Gatsby's SSR (Server Side Rendering) APIs in this file.
- *
- * See: https://www.gatsbyjs.org/docs/ssr-apis/
- */
+import wrapRootElement from './src/components/wrap-root-element';
 
-// You can delete this file if you're not using it
+export { wrapRootElement };

--- a/src/components/wrap-root-element.jsx
+++ b/src/components/wrap-root-element.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+
+import { theme } from '#components';
+
+/*
+ * App wrappers go here!
+ * e.g. ThemeProvider, StateProvider, i18next, etc
+
+*/
+
+export default ({ element }) => {
+  return (
+    <ThemeProvider
+      theme={theme}
+    >
+      {element}
+    </ThemeProvider>
+  );
+};


### PR DESCRIPTION
`wrap-root-element.jsx` created for Gatsby app wrapper customisation. This should be used for app-wide context providers. e.g. `<ThemeProvider>`, `<I18nextProvider>`, Redux initialisation, etc

`components/theme/index.js` is used for app-wide theming (design tokens). See https://styled-system.com/theme-specification for more info.

e.g.

```js
// theme.js
export default {
  colors: {
    primary: 'green',
  }
}
```

```jsx
const Item = () => (
  <Box bg="primary">
    <Text color="white">
      Text Here
    </Text>
  </Box>
);
```