### PR TITLE
Desktop/tablet styling

### DIFF
--- a/components/app/CategoryList.jsx
+++ b/components/app/CategoryList.jsx
@@ -64,17 +64,17 @@ const CategoryImage = ({ source, count, ...props }) => (
   </Box>
 );
 CategoryImage.defaultProps = {
-  width: 100,
-  height: 80,
+  minWidth: 100,
+  height: [80, 100, 120],
 };
 
 const CategoryTile = ({ item: { name, count, source }, ...props }) => (
-  <Box {...props} style={{"text-align":"center"}}>
-  <Link to={`/category/${_.kebabCase(name)}`} style={{ textDecoration: 'none' }}>
-    <CategoryImage count={count} source={source} />
-    <CategoryTitle my={1}>
-      {name}
-    </CategoryTitle>
+  <Box {...props} flex={[null, 1]} style={{ textAlign: 'center' }}>
+    <Link to={`/category/${_.kebabCase(name)}`} style={{ textDecoration: 'none' }}>
+      <CategoryImage count={count} source={source} />
+      <CategoryTitle my={1}>
+        {name}
+      </CategoryTitle>
     </Link>
   </Box>
 );
@@ -88,11 +88,11 @@ const CategoriesHeading = styled(Text)`
 `;
 
 const CategoryList = ({ title, items, ...props }) => (
-  <CategoryBox p={3} {...props}>
+  <CategoryBox alignItems="center" p={3} {...props}>
     <CategoriesHeading mb={3}>
       {title}
     </CategoriesHeading>
-    <Row overflow="scroll">
+    <Row overflow="scroll" width={[null, '100%']} maxWidth={1280}>
       {(items || []).map((item, i) => (
         <CategoryTile key={(item && item.name) || i} mr={!isLast(i, items.length) ? 2 : 0} item={item} />
       ))}

--- a/components/app/Header.jsx
+++ b/components/app/Header.jsx
@@ -1,8 +1,12 @@
-import React from "react"
-import styled from 'styled-components'
-import { Box } from '../atoms';
+import React from "react";
+import styled, { useTheme } from 'styled-components';
 
-const HeaderTitle = styled.p`
+import { useWindowDimensions } from '../hooks';
+import { Box, Text } from '../atoms';
+import theme from '../theme';
+
+
+const HeaderTitle = styled(Text)`
 font-family: Raleway;
 font-style: normal;
 font-weight: bold;
@@ -12,6 +16,9 @@ margin-bottom: 0.75rem;
 margin-top: 0.75rem;
 `
 const HeaderContainer = styled.div`
+display: flex;
+flex-direction: column;
+align-items: center;
 margin: 2vh;
 margin-top: 4vh;
 @media (max-width: 768px) {
@@ -25,14 +32,29 @@ font-weight: 600;
 font-size: 22px;
 line-height: 27px;
 text-align: center;
+max-width: 600px;
 `
+
+/* This renders a line break for mobile only */
+/* This is good for SEO – keeps both lines inside the same h1 element */
+const Br = () => {
+  const { width } = useWindowDimensions();
+  const { breakpoints } = useTheme();
+
+  const maxBreakpointWidth = Number(breakpoints.mobile.replace('px', ''));
+
+  return (
+    <span style={{
+      ...(width <= maxBreakpointWidth  && { display: 'block' })
+    }} />
+  );
+}
 
 const Header = () => {
   return (
-      <Box>
+    <Box minHeight={[390, 390, 200]}>
       <HeaderContainer>
-       <HeaderTitle>Brixton</HeaderTitle>
-       <HeaderTitle>Local.Life</HeaderTitle>
+       <HeaderTitle as="h1" fontSize={[48, 48, 64]}>Brixton<Br />Local.Life</HeaderTitle>
        <HeaderText>Getting the word out for the local community and businesses during the COVID-19 lockdown</HeaderText>
        </HeaderContainer>
       </Box>

--- a/components/app/PlaceItem.jsx
+++ b/components/app/PlaceItem.jsx
@@ -86,15 +86,15 @@ const PlaceInfo = ({ name, category, tags, collection, delivery }) => (
 );
 
 const PlaceItemContainer = ({ children, ...props }) => (
-  <ItemBox {...props}>
+  <Box width={['100%', 'calc(50% - 16px)', 'calc(33.33333% - 16px)']} mx={[null, 8]} {...props}>
     {children}
-  </ItemBox>
+  </Box>
 );
 
-const ItemBox = styled(Box)`
-flex-basis: 25%;
-margin: 16px;
-`
+// const ItemBox = styled(Box)`
+// flex-basis: 25%;
+// margin: 16px;
+// `
 
 const parseImageSource = (url) => {
   const isDriveUrl = url.includes('drive.google.com');

--- a/components/app/PlaceList.jsx
+++ b/components/app/PlaceList.jsx
@@ -1,20 +1,16 @@
 import React from 'react';
 
-import { isLast } from '../utils';
+import { isLast, extendStyles } from '../utils';
 
 import { Box } from '../atoms';
 import PlaceItem from './PlaceItem';
-import styled from 'styled-components';
 
-const PlaceBox = styled(Box)`
-flex-direction: row;
-flex-wrap: wrap;
-justify-content: space-around;
-@media (max-width: 768px) {
- flex-direction:column;
- flex-wrap:no-wrap;
-}
-`
+const PlaceBox = extendStyles(Box, () => ({
+  justifyContent: 'space-around',
+  flexDirection: ['column', 'row'],
+  flexWrap: ['no-wrap', 'wrap'],
+}));
+
 
 const PlaceList = ({ items: places, style, ...props }) => (
   <PlaceBox {...props}>

--- a/components/hooks/index.js
+++ b/components/hooks/index.js
@@ -1,0 +1,1 @@
+export { default as useWindowDimensions } from './useWindowDimensions';

--- a/components/hooks/useWindowDimensions/index.native.js
+++ b/components/hooks/useWindowDimensions/index.native.js
@@ -1,0 +1,1 @@
+export { useWindowDimensions as default } from 'react-native';

--- a/components/hooks/useWindowDimensions/index.sketch.js
+++ b/components/hooks/useWindowDimensions/index.sketch.js
@@ -1,0 +1,1 @@
+export { useWindowDimensions } from 'react-sketchapp';

--- a/components/hooks/useWindowDimensions/index.web.js
+++ b/components/hooks/useWindowDimensions/index.web.js
@@ -1,0 +1,30 @@
+import { useState, useEffect } from 'react';
+
+/* ref: https://usehooks.com/useWindowSize/ */
+export default function useWindowSize() {
+  const isClient = typeof window === 'object';
+
+  function getSize() {
+    return {
+      width: isClient ? window.innerWidth : undefined,
+      height: isClient ? window.innerHeight : undefined
+    };
+  }
+
+  const [windowSize, setWindowSize] = useState(getSize);
+
+  useEffect(() => {
+    if (!isClient) {
+      return false;
+    }
+
+    function handleResize() {
+      setWindowSize(getSize());
+    }
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []); // Empty array ensures that effect is only run on mount and unmount
+
+  return windowSize;
+}

--- a/components/styled.js
+++ b/components/styled.js
@@ -1,38 +1,32 @@
-import { Platform } from 'react-primitives';
+const { Platform } = require('react-primitives');
+
 // FIXME: This is an unmaintained fork! Used for `shouldForwardProp` in native platforms (there's an open PR)
 // Once the issue is merged/resolved, this should be changed back to `styled-components`
-import styledW, { css as cssW, ThemeProvider as ThemeProviderW } from '@elemental-design/styled-components';
-import styledP, { css as cssP, ThemeProvider as ThemeProviderP } from '@elemental-design/styled-components/primitives';
+const styled = Platform.select({
+  web: () => require('@elemental-design/styled-components'),
+  default: () => require('@elemental-design/styled-components/primitives'),
+})();
 
-let styled, ThemeProvider, css;
+function _interopDefault(ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
+const styled_default = _interopDefault(styled);
 
 if (Platform.OS === 'figma') {
-  styled = styledP;
-  ThemeProvider = ThemeProviderP;
-  css = cssP;
-
-  styled.div = styled.View;
-  styled.button = styled.View;
-  styled.span = styled.Text;
-  styled.p = styled.Text;
-  styled.h1 = styled.Text;
-  styled.h2 = styled.Text;
-  styled.h3 = styled.Text;
-  styled.h4 = styled.Text;
-  styled.h5 = styled.Text;
-  styled.h6 = styled.Text;
-  styled.img = styled.Image;
+  styled_default.div = styled_default.View;
+  styled_default.button = styled_default.View;
+  styled_default.span = styled_default.Text;
+  styled_default.p = styled_default.Text;
+  styled_default.h1 = styled_default.Text;
+  styled_default.h2 = styled_default.Text;
+  styled_default.h3 = styled_default.Text;
+  styled_default.h4 = styled_default.Text;
+  styled_default.h5 = styled_default.Text;
+  styled_default.h6 = styled_default.Text;
+  styled_default.img = styled_default.Image;
 } else {
-  styled = styledW;
-  ThemeProvider = ThemeProviderW;
-  css = cssW;
-
-  styled.View = styled.div;
-  styled.Text = styled.span;
-  styled.Image = styled.img.attrs(({ source }) => ({ src: source }));
+  styled_default.View = styled_default.div;
+  styled_default.Text = styled_default.span;
+  styled_default.Image = styled_default.img.attrs(({ source }) => ({ src: source }));
 }
 
-export { ThemeProvider, css };
-
-export default styled;
+module.exports = styled;

--- a/components/theme/index.js
+++ b/components/theme/index.js
@@ -8,10 +8,27 @@ colors.red = colors.reds[5];
 
 const fontSizes = [56, 48, 36, 24, 20, 16, 14];
 
+const breakpoints = ['640px', '1024px', '1280px'];
+
+/* 0dp < mobile < 640dp */
+/* 640dp < tablet < 1024dp */
+/* 1024dp < desktop_small < 1280dp */
+/* 1280dp < desktop_large < ∞dp */
+
+breakpoints.mobile = breakpoints[0];
+breakpoints.tablet = breakpoints[1];
+breakpoints.desktop_small = breakpoints[2];
+breakpoints.desktop_large = breakpoints[3];
+
+// aliases
+breakpoints.desktop = breakpoints.desktop_small;
+
+
 const space = [0, 4, 8, 16, 32, 64, 128];
 
 export default {
   space,
   fontSizes,
+  breakpoints,
   colors,
 };

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -19,6 +19,12 @@ module.exports = {
         // Setting this parameter is also optional
       },
     },
+    {
+      resolve: `gatsby-plugin-styled-components`,
+      options: {
+        // Add any options here
+      },
+    },
     `gatsby-plugin-react-helmet`,
     `gatsby-transformer-sharp`,
     `gatsby-plugin-sharp`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8805,6 +8805,14 @@
         }
       }
     },
+    "gatsby-plugin-styled-components": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-styled-components/-/gatsby-plugin-styled-components-3.3.0.tgz",
+      "integrity": "sha512-NpOeC7QPZGLr3CBBi2LWKiPrpgM2KhvlZ5rb9sNKRb6T2meLf6lSCpQbYqAyOh/h3t8o7AefSY8Op8fxqPQ3TQ==",
+      "requires": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
     "gatsby-react-router-scroll": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -7,11 +7,13 @@
   "dependencies": {
     "@elemental-design/styled-components": "^5.1.0",
     "axios": "^0.19.2",
+    "babel-plugin-styled-components": "^1.10.7",
     "gatsby": "^2.20.12",
     "gatsby-image": "^2.3.1",
     "gatsby-plugin-google-analytics": "^2.3.0",
     "gatsby-plugin-react-helmet": "^3.2.1",
     "gatsby-plugin-sharp": "^2.5.3",
+    "gatsby-plugin-styled-components": "^3.3.0",
     "gatsby-source-filesystem": "^2.2.2",
     "gatsby-transformer-sharp": "^2.4.3",
     "lodash": "^4.17.15",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -61,8 +61,14 @@ const IndexPage = ({ data }) => {
       <Header></Header>
       <CategoryList items={Object.values(categories)} />
       <Box alignItems="center">
-        <Box px={[16, 40, 0]} maxWidth={[null, null, 1280]}>
-          <PlaceList width="100%" items={places} />
+        {/* Tablet is 8px to cancel out marginHorizontal 8px on PlaceItem */}
+        <Box px={[16, 8, 0]} maxWidth={[null, null, 1280]}>
+          <PlaceList
+            width="100%"
+            marginX={[null, null, 2, -2]}
+            width={[null, null, null, 'calc(100% + 16px)']}
+            items={places}
+          />
         </Box>
       </Box>
       {/* {allBusinessData.map(businessData => <PlaceItem businessName={businessData.node.Name}/>)} */}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -60,8 +60,10 @@ const IndexPage = ({ data }) => {
       <NavBar></NavBar>
       <Header></Header>
       <CategoryList items={Object.values(categories)} />
-      <Box px={[16, 40]}>
-        <PlaceList width="100%" items={places} />
+      <Box alignItems="center">
+        <Box px={[16, 40, 0]} maxWidth={[null, null, 1280]}>
+          <PlaceList width="100%" items={places} />
+        </Box>
       </Box>
       {/* {allBusinessData.map(businessData => <PlaceItem businessName={businessData.node.Name}/>)} */}
     </Box>


### PR DESCRIPTION
Keeping the changes fairly simple for now. I want to try experimenting with a masonry layout, but think it'd be overkill for now, as most of the images are square, and this would require some restructuring of the overall design, this can destroy performance too if not done together with virtualisation, progressive loading, etc. The header/cover needs some clean up still.

**Depends on** (merging this PR will also merge):
> #54 

Preview:

![image](https://user-images.githubusercontent.com/6757532/80848992-3501df00-8c0d-11ea-889d-b42d5e682d9f.png)



**Related**
>  #41 