### PR TITLE
Filter out empty tags in tags page

### DIFF
--- a/src/pages/tags.js
+++ b/src/pages/tags.js
@@ -17,10 +17,10 @@ const extractItemData = ({
 
 const normaliseTags = (tags) => {
     if (Array.isArray(tags)) {
-      return tags;
+      return tags.filter(n => n);
     }
     if (typeof tags === 'string') {
-      return tags.split(",");
+      return tags.split(",").filter(n => n);
     }
     return [];
   }
@@ -30,14 +30,14 @@ const Tags = ({data}) => {
   const allTagData = data.allGoogleSheetValue.edges;
   const tags = allTagData.map(extractItemData);
   const flatTagArray = _.flattenDeep(tags).filter(category => category !== "").map(tag => tag.trim()).map(tag => tag.toLowerCase()).sort();
-  const TagMenuArray = flatTagArray.filter((x, i, a) => a.indexOf(x) === i);
+  const tagMenuArray = flatTagArray.filter((x, i, a) => a.indexOf(x) === i);
   
     return (
       <Box>
         <SEO title="Categories page" />
         <NavBar></NavBar>
         <div px={[16, 40]}>
-        <TagMenu width="100%" items={TagMenuArray} />
+        <TagMenu width="100%" items={tagMenuArray} />
         </div>
         {/* {allBusinessData.map(businessData => <PlaceItem businessName={businessData.node.Name}/>)} */}
       </Box>


### PR DESCRIPTION
Also renames `TagMenuArray` to `tagMenuArray` for readability.

Should resolve `Trim if there is a comma at the end of tag list (this causes an empty tag to display)` in #62 .

Made this PR on GitHub web, so haven't tested this locally.